### PR TITLE
Add linux-arm64 support

### DIFF
--- a/.github/workflows/build-wgpu.yml
+++ b/.github/workflows/build-wgpu.yml
@@ -22,6 +22,12 @@ jobs:
             target: x86_64-unknown-linux-gnu
             goos: linux
             goarch: amd64
+          
+          - name: build - linux/arm64
+            os: ubuntu-20.04
+            target: aarch64-unknown-linux-gnu
+            goos: linux
+            goarch: aarch64
 
           - name: build - windows/amd64
             os: windows-2019


### PR DESCRIPTION
This adds linux arm64 as a target for build-wgpu